### PR TITLE
Add test suite and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest pytest-asyncio pytest-benchmark ruff
+      - run: ruff check .
+      - run: pytest --benchmark-min-rounds=1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install flyctl
+      - run: |
+          echo "$FLY_API_TOKEN" | flyctl auth login --access-token -
+          flyctl deploy --remote-only --ha=false
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/app/auth.py
+++ b/app/auth.py
@@ -17,7 +17,7 @@ Usage example::
 
 """
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Header, HTTPException, status
 from typing import Optional
 
 from .config import get_settings

--- a/app/config.py
+++ b/app/config.py
@@ -5,8 +5,8 @@ defaults defined here are sensible for local development.  In production
 environments you should override these values via environment variables.
 """
 from functools import lru_cache
-import os
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 
 class Settings(BaseSettings):

--- a/app/main.py
+++ b/app/main.py
@@ -26,12 +26,12 @@ to report compression metrics.
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Request, Response, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
-import asyncio
+import json
 
 from .auth import get_current_identity
-from .rate_limit import get_rate_limiter, RateLimiter
+from .rate_limit import get_rate_limiter
 from .compression import compress
 from .memory import add_message, get_context
 from .upstream import call_llm

--- a/app/services/qr_retriever.py
+++ b/app/services/qr_retriever.py
@@ -70,7 +70,7 @@ def _load_model() -> Tuple[AutoModelForCausalLM, AutoTokenizer, List[Tuple[int, 
             config = model.peft_config
             rh = config.get("retrieval_heads")  # type: ignore[attr-defined]
             if isinstance(rh, (list, tuple)):
-                retrieval_heads = [(int(l), int(h)) for l, h in rh]
+                retrieval_heads = [(int(layer), int(head)) for layer, head in rh]
         except Exception:
             pass
     return model, tokenizer, retrieval_heads

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.110.0
 uvicorn[standard]>=0.23.0
 httpx>=0.25.0
 pydantic>=2.0.0
+pydantic-settings>=2.0.0
 sqlalchemy>=2.0.0
 transformers>=4.40.0
 peft>=0.9.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,37 @@
+import pytest
+from fastapi import HTTPException
+
+from app import auth, config
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_keys(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "")
+    config.get_settings.cache_clear()
+    identity = await auth.get_current_identity()
+    assert identity == ""
+
+
+@pytest.mark.asyncio
+async def test_accepts_valid_key(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "key1,key2")
+    config.get_settings.cache_clear()
+    identity = await auth.get_current_identity("key2")
+    assert identity == "key2"
+
+
+@pytest.mark.asyncio
+async def test_missing_key_raises(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "abc")
+    config.get_settings.cache_clear()
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_identity(None)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_key_raises(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "valid")
+    config.get_settings.cache_clear()
+    with pytest.raises(HTTPException):
+        await auth.get_current_identity("invalid")

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,16 @@
+
+from app import compression, config
+
+
+def test_compress_delegates_and_uses_settings(monkeypatch):
+    monkeypatch.setenv("TOP_K", "10")
+    config.get_settings.cache_clear()
+
+    def fake_reduce(query, context):
+        assert config.get_settings().top_k == 10
+        return "condensed text", 200, 50
+
+    monkeypatch.setattr(compression.qr_retriever, "reduce", fake_reduce)
+
+    result = compression.compress("question", "context")
+    assert result == ("condensed text", 200, 50)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,35 @@
+import importlib
+
+from app import config
+
+
+def setup_memory(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    config.get_settings.cache_clear()
+    from app import memory
+    importlib.reload(memory)
+    return memory
+
+
+def test_add_and_get_messages(monkeypatch, tmp_path):
+    memory = setup_memory(monkeypatch, tmp_path)
+    memory.add_message("s", "user", "hello", 1)
+    memory.add_message("s", "assistant", "hi", 2)
+    msgs = memory.get_messages("s")
+    assert [m["content"] for m in msgs] == ["hello", "hi"]
+
+
+def test_get_context(monkeypatch, tmp_path):
+    memory = setup_memory(monkeypatch, tmp_path)
+    memory.add_message("sess", "user", "first", 1)
+    memory.add_message("sess", "assistant", "second", 2)
+    context = memory.get_context("sess")
+    assert context == "first\nsecond"
+
+
+def test_clear_session(monkeypatch, tmp_path):
+    memory = setup_memory(monkeypatch, tmp_path)
+    memory.add_message("id", "user", "msg", 1)
+    memory.clear_session("id")
+    assert memory.get_messages("id") == []

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi import HTTPException
+
+import app.rate_limit as rl
+
+
+def test_allows_within_limits(monkeypatch):
+    limiter = rl.RateLimiter(requests_per_minute=2, tokens_per_minute=100)
+    t = 0
+
+    def fake_time():
+        return t
+
+    monkeypatch.setattr(rl, "time", fake_time)
+
+    limiter.check("id", 10)
+    t += 1
+    limiter.check("id", 20)
+
+
+def test_blocks_excess_requests(monkeypatch):
+    limiter = rl.RateLimiter(requests_per_minute=2, tokens_per_minute=100)
+    t = 0
+
+    def fake_time():
+        return t
+
+    monkeypatch.setattr(rl, "time", fake_time)
+
+    limiter.check("id", 1)
+    t += 1
+    limiter.check("id", 1)
+    t += 1
+    with pytest.raises(HTTPException) as exc:
+        limiter.check("id", 1)
+    assert exc.value.status_code == 429
+
+
+def test_blocks_excess_tokens(monkeypatch):
+    limiter = rl.RateLimiter(requests_per_minute=5, tokens_per_minute=100)
+    t = 0
+
+    def fake_time():
+        return t
+
+    monkeypatch.setattr(rl, "time", fake_time)
+
+    limiter.check("id", 60)
+    t += 1
+    with pytest.raises(HTTPException):
+        limiter.check("id", 50)

--- a/tests/test_upstream.py
+++ b/tests/test_upstream.py
@@ -1,0 +1,70 @@
+import pytest
+
+from app import upstream, config
+import httpx
+
+
+@pytest.mark.asyncio
+async def test_call_llm_uses_env_api_key(monkeypatch):
+    monkeypatch.setenv("UPSTREAM_API_KEY", "secret")
+    config.get_settings.cache_clear()
+    captured = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, headers=None, json=None):
+            captured["headers"] = headers
+            return DummyResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+    result = await upstream.call_llm(messages=[{"role": "user", "content": "hi"}])
+    assert result == {"ok": True}
+    assert captured["headers"]["Authorization"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_call_llm_streams(monkeypatch):
+    class StreamResponse:
+        def raise_for_status(self):
+            pass
+
+        async def aiter_lines(self):
+            for line in ['data: {"delta": "hi"}', '', 'data: [DONE]']:
+                yield line
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, headers=None, json=None):
+            return StreamResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+    gen = await upstream.call_llm(messages=[{"role": "u", "content": "h"}], stream=True)
+    events = []
+    async for event in gen:
+        events.append(event)
+    assert events == [{"delta": "hi"}]


### PR DESCRIPTION
## Summary
- add unit tests for authentication, rate limiting, memory, compression, and upstream forwarding
- configure GitHub Actions for linting, tests, and Fly.io deployment
- switch configuration to `pydantic-settings` and document Fly.io deployment steps

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689627358aa88325bae1230de4371f83