### PR TITLE
Use Flyctl GitHub Action for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt
-      - run: pip install flyctl
+      - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: |
           echo "$FLY_API_TOKEN" | flyctl auth login --access-token -
           flyctl deploy --remote-only --ha=false


### PR DESCRIPTION
## Summary
- use the official Fly.io action to install flyctl in the deploy workflow

## Testing
- `ruff check .`
- `pytest --benchmark-min-rounds=1`


------
https://chatgpt.com/codex/tasks/task_e_68965bb3831c832582ce3a2158b33987